### PR TITLE
GitHub plugin - WIP

### DIFF
--- a/bugger/bugger.go
+++ b/bugger/bugger.go
@@ -54,7 +54,7 @@ func (r *bugReporter) printReport(days int) (report string) {
 func (r *bugReporter) printCount(days int) (count string) {
 
 	dayheader := fmt.Sprintf(" BUG COUNT FOR LAST %d DAYS ", days) // 20 spaces
-	bar := "********************"
+	bar := "*************"
 
 	count = fmt.Sprintf("/quote " + bar + dayheader + bar + "\n")
 	count += fmt.Sprintf("|%-30s|%-20s|\n", "team member", "number squashed")

--- a/bugger/bugger.go
+++ b/bugger/bugger.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/plotly/plotbot"
 	"github.com/plotly/plotbot/github"
+	"github.com/plotly/plotbot/utils"
 )
 
 func init() {
@@ -20,15 +21,16 @@ type Bugger struct {
 	ghclient github.Client
 }
 
-type bugReport struct {
-	bugs []github.IssueItem
+type bugReporter struct {
+	bugs    []github.IssueItem
+	Git2Hip map[string]string
 }
 
-func (r *bugReport) addBug(issue github.IssueItem) {
+func (r *bugReporter) addBug(issue github.IssueItem) {
 	r.bugs = append(r.bugs, issue)
 }
 
-func (r *bugReport) printReport(days int) (report string) {
+func (r *bugReporter) printReport(days int) (report string) {
 
 	dayheader := fmt.Sprintf(" BUG REPORT FOR LAST %d DAYS ", days) // 20 spaces
 	bar := "************************"
@@ -49,7 +51,29 @@ func (r *bugReport) printReport(days int) (report string) {
 	return
 }
 
-func (bugger *Bugger) getBugReport(days int) string {
+func (r *bugReporter) printCount(days int) (count string) {
+
+	dayheader := fmt.Sprintf(" BUG COUNT FOR LAST %d DAYS ", days) // 20 spaces
+	bar := "********************"
+
+	count = fmt.Sprintf("/quote " + bar + dayheader + bar + "\n")
+	count += fmt.Sprintf("|%-30s|%-20s|\n", "team member", "number squashed")
+
+	bugcount := make(map[string]int)
+
+	for _, bug := range r.bugs {
+		bugcount[bug.LastClosedBy()]++
+	}
+
+	for _, ghname := range util.SortedKeys(bugcount) {
+		count += fmt.Sprintf("|%-30s|%-20d|\n", ghname, bugcount[ghname])
+	}
+
+	return
+
+}
+
+func (bugger *Bugger) makeBugReporter(days int) (reporter bugReporter) {
 
 	repo := bugger.ghclient.Conf.Repos[0]
 
@@ -62,7 +86,7 @@ func (bugger *Bugger) getBugReport(days int) string {
 	issueList, err := bugger.ghclient.DoSearchQuery(query)
 	if err != nil {
 		log.Print(err)
-		return ""
+		return
 	}
 
 	/*
@@ -71,13 +95,13 @@ func (bugger *Bugger) getBugReport(days int) string {
 	issueChan := make(chan github.IssueItem, 1)
 	go bugger.ghclient.DoEventQuery(issueList, repo, issueChan)
 
-	reporter := bugReport{}
+	reporter.Git2Hip = bugger.ghclient.Conf.Github2Hipchat
 
 	for issue := range issueChan {
 		reporter.addBug(issue)
 	}
 
-	return reporter.printReport(days)
+	return
 }
 
 func (bugger *Bugger) InitChatPlugin(bot *plotbot.Bot) {
@@ -107,40 +131,7 @@ func (bugger *Bugger) ChatHandler(conv *plotbot.Conversation, msg *plotbot.Messa
 
 	if msg.MentionsMe && msg.Contains("bug report") {
 
-		re := regexp.MustCompile(".*(?:last|past) (\\d+)?\\s?(day|week).*")
-		hits := re.FindStringSubmatch(msg.Body)
-
-		var days, weeks int
-		var err error
-
-		if len(hits) == 3 {
-			howmany := hits[1]
-			dayOrWeek := hits[2]
-
-			if dayOrWeek == "day" {
-				if howmany == "" {
-					days = 7
-				} else {
-					days, err = strconv.Atoi(howmany)
-					if err != nil {
-						days = 7
-					}
-				}
-			} else {
-				if howmany == "" {
-					days = 7
-				} else {
-					weeks, err = strconv.Atoi(howmany)
-					if err != nil {
-						days = 7
-					} else {
-						days = 7 * weeks
-					}
-				}
-			}
-		} else {
-			days = 7
-		}
+		days := getDaysFromQuery(msg.Body)
 
 		if days > 31 {
 			conv.Reply(msg, fmt.Sprintf("Whaoz, %d is too much data to compile - well maybe not, I am just scared", days))
@@ -149,10 +140,65 @@ func (bugger *Bugger) ChatHandler(conv *plotbot.Conversation, msg *plotbot.Messa
 
 		conv.Reply(msg, fmt.Sprintf("hang on - let me ping those github kids"))
 
-		bugreport := bugger.getBugReport(days)
+		reporter := bugger.makeBugReporter(days)
+		conv.Reply(msg, reporter.printReport(days))
 
-		conv.Reply(msg, bugreport)
+	} else if msg.MentionsMe && msg.Contains("bug count") {
+
+		days := getDaysFromQuery(msg.Body)
+
+		if days > 31 {
+			conv.Reply(msg, fmt.Sprintf("Whaoz, %d is too much data to compile - well maybe not, I am just scared", days))
+			return
+		}
+
+		conv.Reply(msg, fmt.Sprintf("hang on - let me ping those github kids"))
+
+		reporter := bugger.makeBugReporter(days)
+
+		conv.Reply(msg, reporter.printCount(days))
 	}
+
 	return
 
+}
+
+func getDaysFromQuery(text string) (days int) {
+
+	re := regexp.MustCompile(".*(?:last|past) (\\d+)?\\s?(day|week).*")
+	hits := re.FindStringSubmatch(text)
+
+	var weeks int
+	var err error
+
+	if len(hits) == 3 {
+		howmany := hits[1]
+		dayOrWeek := hits[2]
+
+		if dayOrWeek == "day" {
+			if howmany == "" {
+				days = 7
+			} else {
+				days, err = strconv.Atoi(howmany)
+				if err != nil {
+					days = 7
+				}
+			}
+		} else {
+			if howmany == "" {
+				days = 7
+			} else {
+				weeks, err = strconv.Atoi(howmany)
+				if err != nil {
+					days = 7
+				} else {
+					days = 7 * weeks
+				}
+			}
+		}
+	} else {
+		days = 7
+	}
+
+	return
 }

--- a/bugger/bugger.go
+++ b/bugger/bugger.go
@@ -107,7 +107,7 @@ func (bugger *Bugger) ChatHandler(conv *plotbot.Conversation, msg *plotbot.Messa
 
 	if msg.MentionsMe && msg.Contains("bug report") {
 
-		re := regexp.MustCompile(".*last (\\d+)?\\s?(day|week).*")
+		re := regexp.MustCompile(".*(?:last|past) (\\d+)?\\s?(day|week).*")
 		hits := re.FindStringSubmatch(msg.Body)
 
 		var days, weeks int

--- a/bugger/bugger.go
+++ b/bugger/bugger.go
@@ -1,0 +1,158 @@
+package bugger
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/plotly/plotbot"
+	"github.com/plotly/plotbot/github"
+)
+
+func init() {
+	plotbot.RegisterPlugin(&Bugger{})
+}
+
+type Bugger struct {
+	bot      *plotbot.Bot
+	ghclient github.Client
+}
+
+type bugReport struct {
+	bugs []github.IssueItem
+}
+
+func (r *bugReport) addBug(issue github.IssueItem) {
+	r.bugs = append(r.bugs, issue)
+}
+
+func (r *bugReport) printReport(days int) (report string) {
+
+	dayheader := fmt.Sprintf(" BUG REPORT FOR LAST %d DAYS ", days) // 20 spaces
+	bar := "************************"
+
+	report = fmt.Sprintf("/quote " + bar + dayheader + bar + "\n")
+
+	report += fmt.Sprintf("|%-45s|%-7s|%-18s|\n", "bug title", "number", "squasher")
+	title := ""
+	for _, bug := range r.bugs {
+		if len(bug.Title) > 45 {
+			title = bug.Title[0:42] + "..."
+		} else {
+			title = bug.Title
+		}
+		report += fmt.Sprintf("|%-45s|%-7d|%-18s|\n", title, bug.Number, bug.LastClosedBy())
+	}
+
+	return
+}
+
+func (bugger *Bugger) getBugReport(days int) string {
+
+	repo := bugger.ghclient.Conf.Repos[0]
+
+	query := github.SearchQuery{
+		Repo:        repo,
+		Labels:      []string{"bug"},
+		ClosedSince: time.Now().Add(-time.Duration(days) * (24 * time.Hour)).Format("2006-01-02"),
+	}
+
+	issueList, err := bugger.ghclient.DoSearchQuery(query)
+	if err != nil {
+		log.Print(err)
+		return ""
+	}
+
+	/*
+	 * Get an array of issues matching Filters
+	 */
+	issueChan := make(chan github.IssueItem, 1)
+	go bugger.ghclient.DoEventQuery(issueList, issueChan)
+
+	reporter := bugReport{}
+
+	for issue := range issueChan {
+		reporter.addBug(issue)
+	}
+
+	return reporter.printReport(days)
+}
+
+func (bugger *Bugger) InitChatPlugin(bot *plotbot.Bot) {
+
+	/*
+	 * Get an array of issues matching Filters
+	 */
+	bugger.bot = bot
+
+	var conf struct {
+		Github github.Conf
+	}
+
+	bot.LoadConfig(&conf)
+
+	bugger.ghclient = github.Client{
+		Conf: conf.Github,
+	}
+
+	bot.ListenFor(&plotbot.Conversation{
+		HandlerFunc: bugger.ChatHandler,
+	})
+
+}
+
+func (bugger *Bugger) ChatHandler(conv *plotbot.Conversation, msg *plotbot.Message) {
+
+	if msg.MentionsMe && msg.Contains("bug report") {
+
+		re := regexp.MustCompile(".*last (\\d+)?\\s?(day|week).*")
+		hits := re.FindStringSubmatch(msg.Body)
+
+		var days, weeks int
+		var err error
+
+		if len(hits) == 3 {
+			howmany := hits[1]
+			dayOrWeek := hits[2]
+
+			if dayOrWeek == "day" {
+				if howmany == "" {
+					days = 7
+				} else {
+					days, err = strconv.Atoi(howmany)
+					if err != nil {
+						days = 7
+					}
+				}
+			} else {
+				if howmany == "" {
+					days = 7
+				} else {
+					weeks, err = strconv.Atoi(howmany)
+					if err != nil {
+						days = 7
+					} else {
+						days = 7 * weeks
+					}
+				}
+			}
+		} else {
+			days = 7
+		}
+
+		if days > 31 {
+			conv.Reply(msg, fmt.Sprintf("Whaoz, %d is too much data to compile - well maybe not, I am just scared", days))
+			return
+		}
+
+		conv.Reply(msg, fmt.Sprintf("hang on - let me ping those github kids"))
+
+		bugreport := bugger.getBugReport(days)
+
+		conv.Reply(msg, bugreport)
+	}
+	return
+
+}

--- a/bugger/bugger.go
+++ b/bugger/bugger.go
@@ -69,7 +69,7 @@ func (bugger *Bugger) getBugReport(days int) string {
 	 * Get an array of issues matching Filters
 	 */
 	issueChan := make(chan github.IssueItem, 1)
-	go bugger.ghclient.DoEventQuery(issueList, issueChan)
+	go bugger.ghclient.DoEventQuery(issueList, repo, issueChan)
 
 	reporter := bugReport{}
 

--- a/github/github.go
+++ b/github/github.go
@@ -1,0 +1,150 @@
+package github
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const searchIssueURL = "https://api.github.com/search/issues"
+
+type SearchQuery struct {
+	Repo        string
+	Labels      []string
+	ClosedSince string
+}
+
+type SearchResponse struct {
+	TotalCount int64 `json:"total_count"`
+	Items      []IssueItem
+}
+
+type GHUser struct {
+	Login string
+}
+
+type IssueItem struct {
+	Url       string
+	Title     string
+	Id        int
+	Number    int
+	Milestone string
+	Assignee  GHUser
+	State     string
+	Events    []IssueEvent
+}
+
+type IssueEvent struct {
+	Id    int
+	Actor GHUser
+	Event string
+}
+
+type Conf struct {
+	Authtoken  string
+	Repos      []string
+	GitHipName map[string]string
+}
+
+type Client struct {
+	Conf Conf
+}
+
+func (query *SearchQuery) Url() (url string) {
+
+	url = searchIssueURL
+
+	url += "?q="
+
+	if query.Repo != "" {
+		url += "+repo:" + query.Repo
+	}
+
+	if len(query.Labels) > 0 {
+		for _, value := range query.Labels {
+			url += "+label:" + value
+		}
+	}
+
+	if query.ClosedSince != "" {
+		url += "+closed:>" + query.ClosedSince
+	}
+
+	return
+}
+
+func (issue *IssueItem) LastClosedBy() string {
+	for i := len(issue.Events) - 1; i >= 0; i-- {
+		event := issue.Events[i]
+		if event.Event == "closed" {
+			return event.Actor.Login
+		}
+	}
+	return ""
+}
+
+func (ghclient *Client) Get(url string) (body []byte, err error) {
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+	req.SetBasicAuth(ghclient.Conf.Authtoken, "x-oauth-basic")
+
+	client := http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return
+	}
+
+	body, err = ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		return
+	}
+
+	res.Body.Close()
+
+	return
+}
+
+func (ghclient *Client) DoSearchQuery(query SearchQuery) ([]IssueItem, error) {
+
+	url := query.Url()
+	body, err := ghclient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := SearchResponse{}
+	json.Unmarshal(body, &payload)
+
+	return payload.Items, nil
+}
+
+func (ghclient *Client) DoEventQuery(issueList []IssueItem, issueChan chan IssueItem) {
+
+	defer close(issueChan)
+
+	for _, issue := range issueList {
+
+		url := "https://api.github.com/repos/plotly/streambed/issues/" + strconv.Itoa(issue.Number) + "/events"
+		body, err := ghclient.Get(url)
+		if err != nil {
+			log.Print(err)
+		}
+
+		events := make([]IssueEvent, 0)
+		json.Unmarshal(body, &events)
+
+		issue.Events = events
+		issueChan <- issue
+
+		time.Sleep(500 * time.Millisecond)
+
+	}
+
+}

--- a/github/github.go
+++ b/github/github.go
@@ -125,13 +125,13 @@ func (ghclient *Client) DoSearchQuery(query SearchQuery) ([]IssueItem, error) {
 	return payload.Items, nil
 }
 
-func (ghclient *Client) DoEventQuery(issueList []IssueItem, issueChan chan IssueItem) {
+func (ghclient *Client) DoEventQuery(issueList []IssueItem, repo string, issueChan chan IssueItem) {
 
 	defer close(issueChan)
 
 	for _, issue := range issueList {
 
-		url := "https://api.github.com/repos/plotly/streambed/issues/" + strconv.Itoa(issue.Number) + "/events"
+		url := "https://api.github.com/repos/" + repo + "/issues/" + strconv.Itoa(issue.Number) + "/events"
 		body, err := ghclient.Get(url)
 		if err != nil {
 			log.Print(err)

--- a/github/github.go
+++ b/github/github.go
@@ -44,9 +44,9 @@ type IssueEvent struct {
 }
 
 type Conf struct {
-	Authtoken  string
-	Repos      []string
-	GitHipName map[string]string
+	Authtoken      string
+	Repos          []string
+	Github2Hipchat map[string]string
 }
 
 type Client struct {

--- a/message.go
+++ b/message.go
@@ -46,6 +46,20 @@ func (msg *Message) ContainsAny(strs []string) bool {
 	return false
 }
 
+func (msg *Message) ContainsAll(strs []string) bool {
+
+	lowerStr := strings.ToLower(msg.Body)
+
+	for _, s := range strs {
+		lowerInput := strings.ToLower(s)
+
+		if !strings.Contains(lowerStr, lowerInput) {
+			return false
+		}
+	}
+	return true
+}
+
 func (msg *Message) Contains(s string) bool {
 	lowerStr := strings.ToLower(msg.Body)
 	lowerInput := strings.ToLower(s)

--- a/plotbot.sample.conf
+++ b/plotbot.sample.conf
@@ -65,7 +65,7 @@
   },
 
   "github": {
-    "authtoken": "12345678902345678901234567890123"
+    "authtoken": "put your github auth token here"
     "github2Hipchat": {
       "github-login-name": "hipchat-mention-name"
     },

--- a/plotbot.sample.conf
+++ b/plotbot.sample.conf
@@ -64,11 +64,11 @@
     "session_encrypt_key": "12345678902345678901234567890123"
   },
 
-  "Storm": {
-    "asana_api_key": "12387218........................",
-    "asana_workspace": "629237.......",
-    "hipchat_room": "000000_devops",
-    "storm_tag_id": "15014.........",
-    "calmed_tag_id": "15014........."
+  "github": {
+    "authtoken": "12345678902345678901234567890123"
+    "github2Hipchat": {
+      "github-login-name": "hipchat-mention-name"
+    },
+    "repos": ["plotly/myrepo", "plotly/otherrepo"]
   }
 }

--- a/plotbot/main.go
+++ b/plotbot/main.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"flag"
-	"github.com/plotly/plotbot"
 	"io/ioutil"
 	"os"
 	"strconv"
+
+	"github.com/plotly/plotbot"
 
 	_ "github.com/plotly/plotbot/rewarder"
 
 	_ "github.com/plotly/plotbot/web"
 
+	_ "github.com/plotly/plotbot/bugger"
 	_ "github.com/plotly/plotbot/deployer"
 	_ "github.com/plotly/plotbot/funny"
 	_ "github.com/plotly/plotbot/healthy"
@@ -18,7 +20,6 @@ import (
 	_ "github.com/plotly/plotbot/mooder"
 	_ "github.com/plotly/plotbot/plotberry"
 	_ "github.com/plotly/plotbot/standup"
-	_ "github.com/plotly/plotbot/tabularasa"
 	_ "github.com/plotly/plotbot/totw"
 	_ "github.com/plotly/plotbot/webutils"
 	_ "github.com/plotly/plotbot/wicked"

--- a/utils/sortedMap.go
+++ b/utils/sortedMap.go
@@ -1,3 +1,4 @@
+// pulled from this anonymous playground http://play.golang.org/p/x4CoUsJ5tK
 package util
 
 import "sort"

--- a/utils/sortedMap.go
+++ b/utils/sortedMap.go
@@ -1,0 +1,33 @@
+package util
+
+import "sort"
+
+type sortedMap struct {
+	m map[string]int
+	s []string
+}
+
+func (sm *sortedMap) Len() int {
+	return len(sm.m)
+}
+
+func (sm *sortedMap) Less(i, j int) bool {
+	return sm.m[sm.s[i]] > sm.m[sm.s[j]]
+}
+
+func (sm *sortedMap) Swap(i, j int) {
+	sm.s[i], sm.s[j] = sm.s[j], sm.s[i]
+}
+
+func SortedKeys(m map[string]int) []string {
+	sm := new(sortedMap)
+	sm.m = m
+	sm.s = make([]string, len(m))
+	i := 0
+	for key, _ := range m {
+		sm.s[i] = key
+		i++
+	}
+	sort.Sort(sm)
+	return sm.s
+}


### PR DESCRIPTION
@andrefarzat @scjody @BRONSOLO @alexander-daniel @mkcor @alexcjohnson @etpinard 

Jody and I have discussed increasing the bug fixing culture at Plotly and in the name of transparency I figured this is the best place to start - with code that we can all use.


This PR adds a new plugin to Plotbot that produces a report on bug squashing that looks like:
```
************************ BUG REPORT FOR LAST  14 ************************
|bug title                                    |number |squasher          |
|folders API filetype not filtering           |1971   |bpostlethwaite    |
|folders API inconsistency                    |1970   |bpostlethwaite    |
|Redirect on GET of feed_json_list, etc.      |1878   |andrefarzat       |
|Get rid of .innerText                        |1634   |etpinard          |
|Import from Dropbox icon missing             |1460   |troiska           |
|Feedback doesn't clear after send            |1335   |bpostlethwaite    |
|Fits: results annotation on log axes has i...|1183   |bpostlethwaite    |
```

with calling syntax like:
```
@plot give me a bug report over the last 5 days

@plot produce a bug report   (7 day default)

@plot I want a bug report from the past 2 weeks 

@plot bug report from the past week
```
and other permutations

~~I am also going to implement - unless someone thinks its a bad management idea - a call that will look something like~~ implemented :)
```
@plot, give me a bug count for the last 2 weeks
```
which will print a ~~hipchat mention name~~ ghname with the total bugs squashed for everyone who knocked off a streambed bug in the given time frame and a total number of bugs.

Note, this currently only works for streambed, but I configured it in a way that makes it trivial to add reporting on other repos. 

The core github module will also make it easy to build other reporting tools as well as extending this plugin.