### PR TITLE
Switch to PostMessage in replyHandler

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -342,22 +342,17 @@ func (bot *Bot) LoadConfig(config interface{}) (err error) {
 }
 
 func (bot *Bot) replyHandler() {
-	count := 0
 	for {
 		select {
 		case <-bot.disconnected:
 			return
 		case reply := <-bot.replySink:
 			if reply != nil {
-				//log.Println("REPLYING", reply.To, reply.Message)
-				count += 1
-				err := bot.ws.SendMessage(&slack.OutgoingMessage{
-					Id:        count,
-					ChannelId: reply.To,
-					Type:      "message",
-					Text:      reply.Text,
-				})
+				//log.Println("REPLYING", reply.To, reply.Text)
+				params := slack.PostMessageParameters{}
+				_, _, err := bot.ws.PostMessage(reply.To, reply.Text, params)
 				if err != nil {
+					log.Println("REPLY ERROR")
 					return
 				}
 				time.Sleep(50 * time.Millisecond)


### PR DESCRIPTION
If messages sent via `SendMessage` are too large, we will be disconnected without an error.  `PostMessage` does not have this limitation, and also returns errors on failure.  I haven't been able to make it fail though, so for now we just log when an error is returned.  If a failure ever happens, we'll be able to investigate further.

Fixes https://github.com/plotly/streambed/issues/5533

@perigee and @bpostlethwaite Please review.