### PR TITLE
Failover deploys

### DIFF
--- a/deployer/deployer.go
+++ b/deployer/deployer.go
@@ -135,17 +135,14 @@ func (dep *Deployer) ChatHandler(conv *plotbot.Conversation, msg *plotbot.Messag
 			conv.Reply(msg, fmt.Sprintf("Deployment was locked by %s.  "+
 				"Unlock with '%s, unlock deployment' if they're OK with it.",
 				dep.lockedBy, dep.bot.AtMention()))
-			return
-		}
-		if dep.runningJob != nil {
-			params := dep.runningJob.params
-			conv.Reply(msg, fmt.Sprintf("@%s Deploy currently running: %s",
-				msg.FromUser.Name, params))
-			return
+
+		} else if dep.runningJob != nil {
+			dep.replyPersonnally(params,
+				fmt.Sprintf("Deploy currently running: %s", dep.runningJob.params))
+
 		} else {
 			go dep.handleDeploy(params)
 		}
-		return
 
 	} else if msg.Contains("cancel deploy") {
 
@@ -155,14 +152,12 @@ func (dep *Deployer) ChatHandler(conv *plotbot.Conversation, msg *plotbot.Messag
 			if dep.runningJob.killing == true {
 				conv.Reply(msg,
 					"deploy: Interrupt signal already sent, waiting to die")
-				return
 			} else {
 				conv.Reply(msg, "deploy: Sending Interrupt signal...")
 				dep.runningJob.killing = true
 				dep.runningJob.kill <- true
 			}
 		}
-		return
 	} else if msg.Contains("in the pipe") {
 		url := dep.getCompareUrl("prod", dep.config.DefaultBranch)
 		mention := msg.FromUser.Name

--- a/deployer/deployer_test.go
+++ b/deployer/deployer_test.go
@@ -726,3 +726,28 @@ func TestRunPlaybookConfirmationSuccess(t *testing.T) {
 		t.Errorf("expected '%s' but found '%s'", actual, expected)
 	}
 }
+
+func TestRunHelp(t *testing.T) {
+	dep := defaultTestDep(time.Second)
+
+	dep.ChatHandler(&plotbot.Conversation{Bot: dep.bot},
+		testutils.ToBotMsg(dep.bot, "run help"))
+
+	bot := dep.bot.(*testutils.MockBot)
+	replies := bot.TestReplies
+
+	if len(replies) != 1 {
+		t.Fatalf("expected 1 replies got %d", len(replies))
+	}
+
+	actual := replies[0].Text
+	if !strings.Contains(strings.ToLower(actual), "usage") {
+		t.Errorf("expected reply '%s' to contain '%s'", actual, "usage")
+	}
+	if !strings.Contains(strings.ToLower(actual), "examples") {
+		t.Errorf("expected reply '%s' to contain '%s'", actual, "examples")
+	}
+	if !strings.Contains(strings.ToLower(actual), "postgres_failover") {
+		t.Errorf("expected reply '%s' to contain '%s'", actual, "examples")
+	}
+}

--- a/deployer/deployer_test.go
+++ b/deployer/deployer_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/plotly/plotbot"
 	"github.com/plotly/plotbot/testutils"
+	"github.com/plotly/plotbot/util"
 )
 
 func newTestDep(dconf DeployerConfig, bot plotbot.BotLike, runner Runnable) *Deployer {
@@ -72,11 +73,11 @@ func defaultTestDep(cmdDelay time.Duration) *Deployer {
 		})
 }
 
-func captureProgress(dep *Deployer, waitTime time.Duration) (testutils.Searchable, error) {
+func captureProgress(dep *Deployer, waitTime time.Duration) (util.Searchable, error) {
 
 	timer := time.NewTimer(waitTime)
 	done := make(chan bool, 2)
-	progress := testutils.Searchable{}
+	progress := util.Searchable{}
 	for {
 		select {
 		case <-timer.C:
@@ -170,7 +171,7 @@ func TestStageDeploy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectContain := testutils.Searchable{
+	expectContain := util.Searchable{
 		"ansible-playbook -i tools/",
 		"--tags updt_streambed",
 		"{{ansible-output}}",
@@ -227,7 +228,7 @@ func TestProdDeployWithTags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectContain := testutils.Searchable{"ansible-playbook -i tools/",
+	expectContain := util.Searchable{"ansible-playbook -i tools/",
 		"--tags umwelt",
 		"{{ansible-output}}",
 		"terminated successfully",
@@ -386,7 +387,7 @@ func TestCancelDeploy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectContain := testutils.Searchable{
+	expectContain := util.Searchable{
 		"ansible-playbook",
 		"--tags updt_streambed",
 		"terminated with error: signal: interrupt",
@@ -396,7 +397,7 @@ func TestCancelDeploy(t *testing.T) {
 			expectContain.String())
 	}
 
-	expectNotToContain := testutils.Searchable{
+	expectNotToContain := util.Searchable{
 		"terminated successfully",
 		"{{ansible-output}}",
 	}
@@ -557,7 +558,7 @@ func TestFailedGitFetch(t *testing.T) {
 		testutils.NewDefaultMockBot(),
 		&testutils.MockRunner{
 			ParseVars: func(c string, s ...string) []string {
-				args := testutils.Searchable(s)
+				args := util.Searchable(s)
 				if c == "git" && args.Contains("fetch") {
 					return []string{"GO_CMD_PROCESS_EXIT=99"}
 				}
@@ -596,7 +597,7 @@ func TestFailedGitCheckout(t *testing.T) {
 		testutils.NewDefaultMockBot(),
 		&testutils.MockRunner{
 			ParseVars: func(c string, s ...string) []string {
-				args := testutils.Searchable(s)
+				args := util.Searchable(s)
 				if c == "git" && args.Contains("checkout") {
 					return []string{"GO_CMD_PROCESS_EXIT=99"}
 				}

--- a/deployer/deployer_test.go
+++ b/deployer/deployer_test.go
@@ -151,7 +151,7 @@ func TestCancelDeployNotRunning(t *testing.T) {
 	actual := bot.TestReplies[0].Text
 	expected := "No deploy running, sorry friend.."
 	if actual != expected {
-		t.Errorf("exected '%s' but found '%s'", expected, actual)
+		t.Errorf("expected '%s' but found '%s'", expected, actual)
 	}
 }
 
@@ -198,13 +198,13 @@ func TestStageDeploy(t *testing.T) {
 	actual := bot.TestReplies[0].Text
 	expected := fmt.Sprintf("<@%s> deploying", testutils.DefaultFromUser)
 	if !strings.Contains(actual, expected) {
-		t.Errorf("exected '%s' to contain '%s'", expected, actual)
+		t.Errorf("expected '%s' to contain '%s'", expected, actual)
 	}
 
 	actual = bot.TestReplies[1].Text
 	expected = fmt.Sprintf("<@%s> your deploy was successful", testutils.DefaultFromUser)
 	if actual != expected {
-		t.Errorf("exected '%s' but found '%s'", expected, actual)
+		t.Errorf("expected '%s' but found '%s'", expected, actual)
 	}
 }
 
@@ -237,13 +237,13 @@ func TestProdDeployWithTags(t *testing.T) {
 	actual := bot.TestReplies[0].Text
 	expected := fmt.Sprintf("<@%s> deploying", testutils.DefaultFromUser)
 	if !strings.Contains(actual, expected) {
-		t.Errorf("exected '%s' to contain '%s'", expected, actual)
+		t.Errorf("expected '%s' to contain '%s'", expected, actual)
 	}
 
 	actual = bot.TestReplies[1].Text
 	expected = fmt.Sprintf("<@%s> your deploy was successful", testutils.DefaultFromUser)
 	if actual != expected {
-		t.Errorf("exected '%s' but found '%s'", expected, actual)
+		t.Errorf("expected '%s' but found '%s'", expected, actual)
 	}
 }
 
@@ -274,7 +274,7 @@ func TestLockUnlock(t *testing.T) {
 	actual := bot.TestReplies[0].Text
 	expected := "Deployment is now locked"
 	if !strings.Contains(actual, expected) {
-		t.Fatalf("exected '%s' to contain '%s'", expected, actual)
+		t.Fatalf("expected '%s' to contain '%s'", expected, actual)
 	}
 
 	// Then make sure a deploy fails while locked
@@ -298,7 +298,7 @@ func TestLockUnlock(t *testing.T) {
 	actual = bot.TestReplies[0].Text
 	expected = fmt.Sprintf("Deployment was locked by %s", testutils.DefaultFromUser)
 	if !strings.Contains(actual, expected) {
-		t.Fatalf("exected '%s' to contain '%s'", expected, actual)
+		t.Fatalf("expected '%s' to contain '%s'", expected, actual)
 	}
 
 	// Unlock deployment
@@ -322,7 +322,7 @@ func TestLockUnlock(t *testing.T) {
 	actual = bot.TestReplies[0].Text
 	expected = "Deployment is now unlocked"
 	if !strings.Contains(actual, expected) {
-		t.Fatalf("exected '%s' to contain '%s'", expected, actual)
+		t.Fatalf("expected '%s' to contain '%s'", expected, actual)
 	}
 
 	// Finally make sure we can now deploy
@@ -388,14 +388,14 @@ func TestCancelDeploy(t *testing.T) {
 	actual := bot.TestReplies[1].Text
 	expected := "deploy: Sending Interrupt signal"
 	if !strings.Contains(actual, expected) {
-		t.Errorf("exected '%s' to contain '%s'", actual, expected)
+		t.Errorf("expected '%s' to contain '%s'", actual, expected)
 	}
 
 	actual = bot.TestReplies[2].Text
 	expected = fmt.Sprintf("<@%s> your deploy failed: signal: interrupt",
 		testutils.DefaultFromUser)
 	if !strings.Contains(actual, expected) {
-		t.Errorf("exected '%s' to contain '%s'", actual, expected)
+		t.Errorf("expected '%s' to contain '%s'", actual, expected)
 	}
 }
 
@@ -658,21 +658,21 @@ func TestRunPlaybookConfirmationBlockingAndTimeout(t *testing.T) {
 		"Confirm with '@%s: [yes|no]'",
 		testutils.DefaultFromUser, bot.Config.Nickname)
 	if !strings.Contains(actual, expected) {
-		t.Errorf("exected '%s' to contain '%s'", expected, actual)
+		t.Errorf("expected '%s' to contain '%s'", expected, actual)
 	}
 
 	actual = bot.TestReplies[1].Text
 	expected = fmt.Sprintf("<@%s> waiting for confirmation from %s",
 		otherUser, testutils.DefaultFromUser)
 	if !strings.Contains(actual, expected) {
-		t.Errorf("exected '%s' to contain '%s'", expected, actual)
+		t.Errorf("expected '%s' to contain '%s'", expected, actual)
 	}
 
 	actual = bot.TestReplies[2].Text
 	expected = fmt.Sprintf("<@%s> Did not receive confirmation in time. "+
 		"Cancelling job", testutils.DefaultFromUser)
 	if !strings.Contains(actual, expected) {
-		t.Errorf("exected '%s' but found '%s'", expected, actual)
+		t.Errorf("expected '%s' but found '%s'", expected, actual)
 	}
 }
 

--- a/deployer/params.go
+++ b/deployer/params.go
@@ -2,27 +2,19 @@ package deployer
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/plotly/plotbot"
 )
 
 type DeployParams struct {
+	Playbook        string
 	Environment     string
 	Branch          string
 	Tags            string
 	InitiatedBy     string
 	From            string
 	initiatedByChat *plotbot.Message
-}
-
-// ParsedTags returns *default* or user-specified tags
-func (p *DeployParams) ParsedTags() string {
-	tags := strings.Replace(p.Tags, " ", "", -1)
-	if tags == "" {
-		tags = "updt_streambed"
-	}
-	return tags
+	Confirm         bool
 }
 
 func (p *DeployParams) String() string {
@@ -31,7 +23,7 @@ func (p *DeployParams) String() string {
 		branch = "[default]"
 	}
 
-	str := fmt.Sprintf("env=%s branch=%s tags=%s", p.Environment, branch, p.ParsedTags())
+	str := fmt.Sprintf("env=%s branch=%s tags=%s", p.Environment, branch, p.Tags)
 
 	str = fmt.Sprintf("%s by %s", str, p.InitiatedBy)
 

--- a/deployer/params.go
+++ b/deployer/params.go
@@ -2,6 +2,8 @@ package deployer
 
 import (
 	"fmt"
+	"io/ioutil"
+	"regexp"
 
 	"github.com/plotly/plotbot"
 )
@@ -28,4 +30,21 @@ func (p *DeployParams) String() string {
 	str = fmt.Sprintf("%s by %s", str, p.InitiatedBy)
 
 	return str
+}
+
+var playbookRegex = regexp.MustCompile(`^playbook_(stage|prod)_(.*).yml$`)
+
+func listAllowedPlaybooks(path string) ([]string, error) {
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	playbooks := []string{}
+	for _, file := range files {
+		if match := playbookRegex.FindStringSubmatch(file.Name()); match != nil {
+			playbooks = append(playbooks, match[2])
+		}
+	}
+
+	return playbooks, nil
 }

--- a/testutils/messages.go
+++ b/testutils/messages.go
@@ -9,45 +9,44 @@ import (
 
 var DefaultFromUser = "hodor"
 
-func applyFromUserToMessage(m plotbot.Message, user string) plotbot.Message {
+func applyFromUserToMessage(m *plotbot.Message, user string) {
 	m.FromUser.Id = user
 	m.FromUser.Name = user
+	m.FromUser.RealName = user
+
 	m.SubMessage.Username = user
 	m.SubMessage.Id = user
+
 	m.Username = user
 	m.UserId = user
-
-	return m
 }
 
-func ToBotMsg(bot plotbot.BotLike, msg string) plotbot.Message {
+func ToBotMsg(bot plotbot.BotLike, msg string) *plotbot.Message {
 
 	msg = fmt.Sprintf("@%s %s", bot.Id(), msg)
-
 	channelId := "channelId"
 
 	smsg := &slack.Msg{
 		Id:        "abcdef",
-		UserId:    "",
-		Username:  "",
 		ChannelId: channelId,
 		Text:      msg,
 	}
 
-	suser := &slack.User{
-		Id:   "",
-		Name: "",
-	}
+	suser := &slack.User{}
 
-	return applyFromUserToMessage(plotbot.Message{
+	m := &plotbot.Message{
 		Msg:        smsg,
 		SubMessage: smsg,
 		FromUser:   suser,
 		MentionsMe: true,
 		FromMe:     false,
-	}, DefaultFromUser)
+	}
+	applyFromUserToMessage(m, DefaultFromUser)
+	return m
 }
 
-func ToBotMsgFromUser(bot plotbot.BotLike, msg, user string) plotbot.Message {
-	return applyFromUserToMessage(ToBotMsg(bot, msg), user)
+func ToBotMsgFromUser(bot plotbot.BotLike, msg, user string) *plotbot.Message {
+	m := ToBotMsg(bot, msg)
+	applyFromUserToMessage(m, user)
+	return m
 }

--- a/testutils/mockrunner.go
+++ b/testutils/mockrunner.go
@@ -4,23 +4,25 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/plotly/plotbot/util"
 )
 
 type MockRunner struct {
-	Jobs        []Searchable
+	Jobs        []util.Searchable
 	ParseVars   func(string, ...string) []string
 	TestCmdName string
 }
 
 func ClearMockRunner(r *MockRunner) {
-	r.Jobs = []Searchable{}
+	r.Jobs = []util.Searchable{}
 }
 
 // see https://npf.io/2015/06/testing-exec-command/
 func (r *MockRunner) Run(c string, s ...string) *exec.Cmd {
 
 	allc := append([]string{c}, s...)
-	r.Jobs = append(r.Jobs, Searchable(allc))
+	r.Jobs = append(r.Jobs, util.Searchable(allc))
 
 	testcmd := r.TestCmdName
 	if testcmd == "" {

--- a/util/searchable.go
+++ b/util/searchable.go
@@ -1,4 +1,4 @@
-package testutils
+package util
 
 import (
 	"fmt"
@@ -30,6 +30,36 @@ func (ps Searchable) ContainsAll(ss ...string) bool {
 func (ps Searchable) ContainsAny(ss ...string) bool {
 	for _, s := range ss {
 		if ps.Contains(s) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ps Searchable) Includes(s string) bool {
+	for _, p := range ps {
+		if p == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ps Searchable) IncludesAll(ss ...string) bool {
+	for _, s := range ss {
+		if !ps.Includes(s) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (ps Searchable) IncludesAny(ss ...string) bool {
+	for _, s := range ss {
+		if ps.Includes(s) {
 			return true
 		}
 	}


### PR DESCRIPTION
@scjody 

basic usage:
```
@plotbot run help?
@plotbot please run postgres_recovery on stage
[ asks for confirmation ]
@plotbot yes please!
```
other usage is covered by tests and help section.

Check #bottest and #bottest2 for a demonstration of failover and recovery working with mobot.

This PR includes some refactoring - refactor work is included in separate commits. 

Next up: Playbook or script that changes a fileMeta on master and then checks for that change by direct PSQL query on the Slave as a way to ensure replication is functioning. Tie this into @plotbot so I can sanity check at 3am after waking from a bad Devops nightmare.

In Future: Substantive refactor of the way we are using Goroutines and Channels in Deployer and Plotbot in general. Right now we are blithely sharing pointer to structs within Goroutines which is not thread safe and opens us up to many race conditions. Checking from Goroutine A that dep.runningJob != nil because some other Goroutine also has write access to dep is a fairly shoddy infrastructure. Running `go test -race` leads to walls of fail. Part of this can be rewriting Deployer so it is more flexible with the type of Jobs it can run. That will more easily allow 2 playbooks to be run as part of a single command alias. Anyway it works...



