### PR TITLE
Support imageserver deployment

### DIFF
--- a/deployer/deployer.go
+++ b/deployer/deployer.go
@@ -386,7 +386,7 @@ func (dep *Deployer) handleDeploy(params *DeployParams) {
 
 	wd := filepath.Join(serviceArgs.RepositoryPath, "tools/watch_deployment")
 	if _, err := os.Stat(wd); !os.IsNotExist(err) {
-		cmd = exec.Command(wd)
+		cmd = dep.runner.Run(wd)
 		cmd.Dir = serviceArgs.RepositoryPath
 
 		err := dep.runWithOutput(cmd, params)
@@ -521,7 +521,7 @@ func (dep *Deployer) getCompareUrl(env, branch, path string) string {
 		return ""
 	}
 
-	cmd := exec.Command(itp, (*dep.internal.Config)[env].BaseURL, (*dep.internal.Config)[env].AuthKey, env, branch)
+	cmd := dep.runner.Run(itp, (*dep.internal.Config)[env].BaseURL, (*dep.internal.Config)[env].AuthKey, env, branch)
 	cmd.Dir = path
 
 	out, err := cmd.CombinedOutput()

--- a/deployer/deployer.go
+++ b/deployer/deployer.go
@@ -335,7 +335,7 @@ func (dep *Deployer) handleDeploy(params *DeployParams) {
 		cmdArgs = append(cmdArgs, "-e", pr)
 	}
 
-	if err := dep.pullRepo(branch); err != nil {
+	if err := dep.pullRepo(branch, serviceArgs.RepositoryPath); err != nil {
 		errorMsg := fmt.Sprintf("Unable to pull from repo: %s. Aborting.", err)
 		dep.pubLine(fmt.Sprintf("[deployer] %s", errorMsg))
 		dep.replyPersonnally(params, errorMsg)
@@ -399,15 +399,15 @@ func (dep *Deployer) handleDeploy(params *DeployParams) {
 	dep.runningJob = nil
 }
 
-func (dep *Deployer) pullRepo(branch string) error {
+func (dep *Deployer) pullRepo(branch, path string) error {
 	cmd := dep.runner.Run("git", "fetch")
-	cmd.Dir = dep.config.Services["streambed"].RepositoryPath
+	cmd.Dir = path
 	err := cmd.Run()
 	if err != nil {
 		return fmt.Errorf("Error executing git fetch: %s", err)
 	}
 	cmd = dep.runner.Run("git", "checkout", fmt.Sprintf("origin/%s", branch))
-	cmd.Dir = dep.config.Services["streambed"].RepositoryPath
+	cmd.Dir = path
 	return cmd.Run()
 }
 

--- a/deployer/deployer.go
+++ b/deployer/deployer.go
@@ -331,7 +331,7 @@ func (dep *Deployer) handleDeploy(params *DeployParams) {
 			}
 		}
 		branch = params.Branch
-		pr := fmt.Sprintf("streambed_pull_revision=origin/%s", params.Branch)
+		pr := fmt.Sprintf("%s_pull_revision=origin/%s", service, params.Branch)
 		cmdArgs = append(cmdArgs, "-e", pr)
 	}
 
@@ -362,7 +362,7 @@ func (dep *Deployer) handleDeploy(params *DeployParams) {
 		fmt.Sprintf("[deployer] Running cmd: %s", strings.Join(cmdArgs, " ")))
 
 	cmd := dep.runner.Run(cmdArgs[0], cmdArgs[1:]...)
-	cmd.Dir = dep.config.Services["streambed"].RepositoryPath
+	cmd.Dir = serviceArgs.RepositoryPath
 	env := append(os.Environ(), "ANSIBLE_NOCOLOR=1")
 	if cmd.Env != nil {
 		env = append(env, cmd.Env...)

--- a/deployer/deployer.go
+++ b/deployer/deployer.go
@@ -65,7 +65,7 @@ var CONFIRM_PLAYBOOKS = util.Searchable{
 
 var deployFormat = regexp.MustCompile(`deploy( ([a-zA-Z0-9_\.-]+))? to (([a-z_-]+) )?([a-z_-]+)((,| with)? tags?:? ?(.+))?`)
 
-var runFormat = regexp.MustCompile(`run\s+([a-zA-Z0-9_\.-]+)\s+on\s+([a-z_-]+)((,|\s*with)?\s+tags?:? ?(.+))?`)
+var runFormat = regexp.MustCompile(`run\s+([a-zA-Z0-9_\.-]+)\s+on\s+(([a-z_-]+)\s+)?([a-z_-]+)((,|\s*with)?\s+tags?:? ?(.+))?`)
 
 type Deployer struct {
 	runner         Runnable
@@ -173,10 +173,15 @@ func (dep *Deployer) ExtractDeployParams(msg *plotbot.Message) *DeployParams {
 		}
 
 	} else if match := runFormat.FindStringSubmatch(msg.Text); match != nil {
+		service := match[3]
+		if service == "" {
+			service = "streambed"
+		}
 		return &DeployParams{
+			Service:         service,
 			Playbook:        match[1],
-			Environment:     match[2],
-			Tags:            match[5],
+			Environment:     match[4],
+			Tags:            match[7],
 			InitiatedBy:     msg.FromUser.RealName,
 			From:            "chat",
 			initiatedByChat: msg,

--- a/deployer/deployer.go
+++ b/deployer/deployer.go
@@ -373,13 +373,29 @@ func (dep *Deployer) handleDeploy(params *DeployParams) {
 	if err != nil {
 		dep.pubLine(fmt.Sprintf("[deployer] terminated with error: %s", err))
 		dep.replyPersonnally(params, fmt.Sprintf("your deploy failed: %s", err))
-	} else {
 
-		dep.pubLine("[deployer] terminated successfully")
-		dep.replyPersonnally(params,
-			bot.WithMood("your deploy was successful",
-				"your deploy was GREAT, you're great !"))
+		return
 	}
+
+	wd := filepath.Join(serviceArgs.RepositoryPath, "tools/watch_deployment")
+	if _, err := os.Stat(wd); !os.IsNotExist(err) {
+		cmd = exec.Command(wd)
+		cmd.Dir = serviceArgs.RepositoryPath
+
+		err := dep.runWithOutput(cmd, params)
+
+		if err != nil {
+			dep.pubLine(fmt.Sprintf("[deployer] terminated with error: %s", err))
+			dep.replyPersonnally(params, fmt.Sprintf("your deploy failed: %s", err))
+
+			return
+		}
+	}
+
+	dep.pubLine("[deployer] terminated successfully")
+	dep.replyPersonnally(params,
+		bot.WithMood("your deploy was successful",
+			"your deploy was GREAT, you're great !"))
 	return
 }
 

--- a/deployer/deployer_test.go
+++ b/deployer/deployer_test.go
@@ -24,28 +24,29 @@ func newTestDep(dconf DeployerConfig, bot plotbot.BotLike, runner Runnable) *Dep
 		log.Fatal(err)
 	}
 
-	defaultdconf := DeployerConfig{
-		RepositoryPath:      filepath.Dir(execPath),
-		AnnounceRoom:        "#streambed",
-		ProgressRoom:        "#deploy",
-		DefaultBranch:       "production",
-		AllowedProdBranches: []string{"master"},
+	serviceConfigs := map[string]ServiceConfig{
+		"streambed": {
+			RepositoryPath:      filepath.Dir(execPath),
+			DefaultBranch:       "production",
+			AllowedProdBranches: []string{"master"},
+			InventoryArgs:       []string{"-i", "tools/plotly_gce"},
+		},
 	}
 
-	if dconf.RepositoryPath != "" {
-		defaultdconf.RepositoryPath = dconf.RepositoryPath
+	defaultdconf := DeployerConfig{
+		AnnounceRoom: "#streambed",
+		ProgressRoom: "#deploy",
+		Services:     serviceConfigs,
+	}
+
+	if dconf.Services != nil {
+		defaultdconf.Services = dconf.Services
 	}
 	if dconf.AnnounceRoom != "" {
 		defaultdconf.AnnounceRoom = dconf.AnnounceRoom
 	}
 	if dconf.ProgressRoom != "" {
 		defaultdconf.ProgressRoom = dconf.ProgressRoom
-	}
-	if dconf.DefaultBranch != "" {
-		defaultdconf.DefaultBranch = dconf.DefaultBranch
-	}
-	if len(dconf.AllowedProdBranches) != 0 {
-		defaultdconf.AllowedProdBranches = dconf.AllowedProdBranches
 	}
 
 	return &Deployer{

--- a/deployer/deployer_test.go
+++ b/deployer/deployer_test.go
@@ -212,7 +212,7 @@ func TestStageDeploy(t *testing.T) {
 func TestProdDeployWithTags(t *testing.T) {
 	dep := defaultTestDep(time.Second)
 	dep.ChatHandler(&plotbot.Conversation{Bot: dep.bot},
-		testutils.ToBotMsg(dep.bot, "deploy to prod with tags: umwelt"))
+		testutils.ToBotMsg(dep.bot, "deploy to prod, tags: umwelt"))
 
 	progress, err := captureProgress(dep, time.Second*2)
 	if err != nil {
@@ -591,7 +591,7 @@ func TestFailedAnsible(t *testing.T) {
 		})
 
 	dep.ChatHandler(&plotbot.Conversation{Bot: dep.bot},
-		testutils.ToBotMsg(dep.bot, "deploy to prod with tags: onions"))
+		testutils.ToBotMsg(dep.bot, "deploy to prod, tags: onions"))
 
 	progress, err := captureProgress(dep, time.Millisecond*500)
 	if err != nil {

--- a/deployer/deployer_test.go
+++ b/deployer/deployer_test.go
@@ -2,9 +2,7 @@ package deployer
 
 import (
 	"fmt"
-	"log"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,14 +17,9 @@ var TEST_CONFIRM_TIMEOUT = time.Second
 
 func newTestDep(dconf DeployerConfig, bot plotbot.BotLike, runner Runnable) *Deployer {
 
-	execPath, err := os.Executable()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	serviceConfigs := map[string]ServiceConfig{
 		"streambed": {
-			RepositoryPath:      filepath.Dir(execPath),
+			RepositoryPath:      "/usr/local",
 			DefaultBranch:       "production",
 			AllowedProdBranches: []string{"master"},
 			InventoryArgs:       []string{"-i", "tools/plotly_gce"},
@@ -127,6 +120,13 @@ func TestCmdProcess(t *testing.T) {
 		time.Sleep(time.Second * time.Duration(i))
 	}
 
+	cwd, err := os.Getwd()
+	if err == nil {
+		fmt.Printf("GO_CMD_WD=%s\n", cwd)
+	} else {
+		fmt.Printf("Error determining working directory: %s\n", err)
+	}
+
 	output := os.Getenv("GO_CMD_PROCESS_OUTPUT")
 	if output != "" {
 		fmt.Println(output)
@@ -168,6 +168,7 @@ func TestStageDeploy(t *testing.T) {
 
 	expectContain := util.Searchable{
 		"ansible-playbook -i tools/",
+		"GO_CMD_WD=/usr/local",
 		"--tags updt_streambed",
 		"{{ansible-output}}",
 		"terminated successfully",
@@ -220,6 +221,7 @@ func TestProdDeployWithTags(t *testing.T) {
 	}
 
 	expectContain := util.Searchable{"ansible-playbook -i tools/",
+		"GO_CMD_WD=/usr/local",
 		"--tags umwelt",
 		"{{ansible-output}}",
 		"terminated successfully",
@@ -696,6 +698,7 @@ func TestRunPlaybookConfirmationSuccess(t *testing.T) {
 	}
 
 	expectContain := util.Searchable{
+		"GO_CMD_WD=/usr/local",
 		"playbook_stage_postgres_recovery.yml",
 		"{{ansible-output}}",
 		"terminated successfully",

--- a/deployer/deployer_test.go
+++ b/deployer/deployer_test.go
@@ -24,6 +24,11 @@ func newTestDep(dconf DeployerConfig, bot plotbot.BotLike, runner Runnable) *Dep
 			AllowedProdBranches: []string{"master"},
 			InventoryArgs:       []string{"-i", "tools/plotly_gce"},
 		},
+		"testrepo": {
+			RepositoryPath:      "/tmp",
+			DefaultBranch:       "testbranch",
+			AllowedProdBranches: []string{"master"},
+		},
 	}
 
 	defaultdconf := DeployerConfig{
@@ -247,6 +252,66 @@ func TestProdDeployWithTags(t *testing.T) {
 	expected = fmt.Sprintf("<@%s> your deploy was successful", testutils.DefaultFromUser)
 	if actual != expected {
 		t.Errorf("expected '%s' but found '%s'", expected, actual)
+	}
+}
+
+func TestDeployOtherService(t *testing.T) {
+	dep := defaultTestDep(time.Second)
+	dep.ChatHandler(&plotbot.Conversation{Bot: dep.bot},
+		testutils.ToBotMsg(dep.bot, "deploy to testrepo prod"))
+
+	progress, err := captureProgress(dep, time.Second*2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectContain := util.Searchable{"ansible-playbook playbook_prod.yml",
+		"GO_CMD_WD=/tmp",
+		"{{ansible-output}}",
+		"terminated successfully",
+	}
+
+	if !progress.ContainsAll(expectContain...) {
+		t.Errorf("expected progress %s to contain all of %s", progress.String(),
+			expectContain.String())
+	}
+
+	bot := dep.bot.(*testutils.MockBot)
+	if len(bot.TestReplies) != 2 {
+		t.Fatalf("expected 2 replies found %d", len(bot.TestReplies))
+	}
+}
+
+func TestDeployInvalidService(t *testing.T) {
+	dep := defaultTestDep(0)
+
+	dep.ChatHandler(&plotbot.Conversation{Bot: dep.bot},
+		testutils.ToBotMsg(dep.bot, "deploy to invalid stage"))
+
+	progress, err := captureProgress(dep, time.Millisecond*500)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectContain := util.Searchable{
+		"invalid is not a valid service",
+	}
+
+	if !progress.ContainsAll(expectContain...) {
+		t.Errorf("expected progress %s to contain all of %s", progress.String(),
+			expectContain.String())
+	}
+
+	bot := dep.bot.(*testutils.MockBot)
+	replies := bot.TestReplies
+	if len(replies) != 1 {
+		t.Fatalf("expected 1 reply got %d", len(replies))
+	}
+
+	actual := replies[0].Text
+	expected := "invalid is not a valid service"
+	if !strings.Contains(actual, expected) {
+		t.Errorf("expected reply '%s' to contain '%s'", actual, expected)
 	}
 }
 
@@ -767,5 +832,47 @@ func TestRunHelp(t *testing.T) {
 	}
 	if !strings.Contains(strings.ToLower(actual), "postgres_failover") {
 		t.Errorf("expected reply '%s' to contain '%s'", actual, "examples")
+	}
+}
+
+func TestRunOtherService(t *testing.T) {
+	dep := defaultTestDep(time.Second * 1)
+
+	dep.ChatHandler(&plotbot.Conversation{Bot: dep.bot},
+		testutils.ToBotMsg(dep.bot, "run testcmd on testrepo stage"))
+
+	progress, err := captureProgress(dep, time.Second*2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectContain := util.Searchable{
+		"GO_CMD_WD=/tmp",
+		"ansible-playbook playbook_stage_testcmd.yml",
+		"{{ansible-output}}",
+		"terminated successfully",
+	}
+
+	if !progress.ContainsAll(expectContain...) {
+		t.Errorf("expected progress %s to contain all of %s", progress.String(),
+			expectContain.String())
+	}
+
+	bot := dep.bot.(*testutils.MockBot)
+	if len(bot.TestReplies) != 2 {
+		t.Fatalf("expected 2 replies found %d", len(bot.TestReplies))
+	}
+
+	actual := bot.TestReplies[0].Text
+	expected := fmt.Sprintf("<@%s> deploying, my friend", testutils.DefaultFromUser)
+	if !strings.Contains(actual, expected) {
+		t.Errorf("expected '%s' but found '%s'", actual, expected)
+	}
+
+	actual = bot.TestReplies[1].Text
+	expected = fmt.Sprintf("<@%s> your deploy was successful",
+		testutils.DefaultFromUser)
+	if !strings.Contains(actual, expected) {
+		t.Errorf("expected '%s' but found '%s'", actual, expected)
 	}
 }

--- a/deployer/params.go
+++ b/deployer/params.go
@@ -12,6 +12,7 @@ import (
 
 type DeployParams struct {
 	Playbook        string
+	Service         string
 	Environment     string
 	Branch          string
 	Tags            string
@@ -27,7 +28,7 @@ func (p *DeployParams) String() string {
 		branch = "[default]"
 	}
 
-	str := fmt.Sprintf("env=%s branch=%s tags=%s", p.Environment, branch, p.Tags)
+	str := fmt.Sprintf("service=%s env=%s branch=%s tags=%s", p.Service, p.Environment, branch, p.Tags)
 
 	str = fmt.Sprintf("%s by %s", str, p.InitiatedBy)
 


### PR DESCRIPTION
Part of https://github.com/plotly/streambed/issues/9865

The basic design is to enhance the deployment module to have the concept of "services". Each service gets defined in Plotbot's config, and we'll start off with "streambed" and "imageserver". Each service has its own (configurable) repo, and we deploy mostly as usual:
* The repo is updated to the desired version (usually the tip of a branch).
* A playbook from the `deployment/` directory in that repo is run.
  * In the case of the imageserver service, this will figure out the correct Docker image tag to use, roll out that image using kubectl, and monitor rollout status until it completes or fails.
* Results are reported to `#deploy`.
* If a `watch_deployment` command exists, it will then be run to watch the deployment until it completes.

"run" abilities are similarly enhanced. Current "run" use cases for the imageserver service:
* Roll back a deployment.
* Update the plotly.js version used by image-exporter.

`watch_deployment` is needed because there's no way in Ansible to do either of:
* Run a command and show its output to the user while it's running
* Repeatedly run a command until it returns a successful error status and show the output of each run

Example commands:
`@plotbot deploy jodys-amazing-branch to imageserver stage`
`@plotbot run update-plotlyjs on imageserver prod`