### PR TITLE
add more verbosity for clearer action to fix misuse

### DIFF
--- a/standup/conversation.go
+++ b/standup/conversation.go
@@ -109,7 +109,7 @@ func (standup *Standup) manageUpdatesInteraction() {
 			remain := strings.Join(remains, " or ")
 
 			if remain != "" {
-				standup.bot.ReplyMention(msg, fmt.Sprintf("what about %s ?", remain))
+				standup.bot.ReplyMention(msg, fmt.Sprintf("what about %s ? Could you please copy your message, paste it back, change it to fix this and sent it again ? (I didn't have my coffee this morning) ", remain))
 			}
 		}
 	}


### PR DESCRIPTION
When the bot asks to fix the standup message, it's not so clear to what should be done to fix, one could think editing the slack message fixes it when it doesn't, so poor bot is confused